### PR TITLE
Fixed PendingFileRenameOperations Query

### DIFF
--- a/source/Public/Test-PendingReboot.ps1
+++ b/source/Public/Test-PendingReboot.ps1
@@ -148,7 +148,7 @@ function Test-PendingReboot
                     CimSession = $CimSession
                     Namespace  = 'root\CIMv2'
                     ClassName  = 'StdRegProv'
-                    Name       = 'EnumKey'
+                    MethodName = 'EnumKey'
                     Arguments  = @{
                         hDefKey     = [UInt32] "0x80000002" # HKLM
                         sSubKeyName = $null
@@ -169,7 +169,7 @@ function Test-PendingReboot
                 $PendingDomainJoin = ($RegistryNetlogon -contains 'JoinDomain') -or ($RegistryNetlogon -contains 'AvoidSpnSet')
 
                 ## Query ComputerName and ActiveComputerName from the registry and setting the MethodName to GetMultiStringValue
-                $InvokeCimMethodSplat.Name = 'GetStringValue'
+                $InvokeCimMethodSplat.MethodName = 'GetStringValue'
 
                 $InvokeCimMethodSplat.Arguments.sSubKeyName = 'SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName'
                 $InvokeCimMethodSplat.Arguments.sValueName = 'ComputerName'
@@ -189,7 +189,7 @@ function Test-PendingReboot
                     $RegistryPendingFileRenameOperations = (Invoke-CimMethod @InvokeCimMethodSplat).sValue
                     if ($null -eq $RegistryPendingFileRenameOperations)
                     {
-                        $InvokeCimMethodSplat.Name = 'GetMultiStringValue'
+                        $InvokeCimMethodSplat.MethodName = 'GetMultiStringValue'
                         $RegistryPendingFileRenameOperations = (Invoke-CimMethod @InvokeCimMethodSplat).sValue
 
                     }
@@ -204,7 +204,7 @@ function Test-PendingReboot
                         CimSession  = $CimSession
                         Namespace   = 'root\ccm\ClientSDK'
                         ClassName   = 'CCM_ClientUtilities'
-                        Name        = 'DetermineifRebootPending'
+                        MethodName  = 'DetermineifRebootPending'
                     }
 
                     $SCCMClientSDKError = $null

--- a/source/Public/Test-PendingReboot.ps1
+++ b/source/Public/Test-PendingReboot.ps1
@@ -187,6 +187,12 @@ function Test-PendingReboot
                     $InvokeCimMethodSplat.Arguments.sSubKeyName = 'SYSTEM\CurrentControlSet\Control\Session Manager'
                     $InvokeCimMethodSplat.Arguments.sValueName = 'PendingFileRenameOperations'
                     $RegistryPendingFileRenameOperations = (Invoke-CimMethod @InvokeCimMethodSplat).sValue
+                    if ($null -eq $RegistryPendingFileRenameOperations)
+                    {
+                        $InvokeCimMethodSplat.Name = 'GetMultiStringValue'
+                        $RegistryPendingFileRenameOperations = (Invoke-CimMethod @InvokeCimMethodSplat).sValue
+
+                    }
                     $RegistryPendingFileRenameOperationsBool = [bool]$RegistryPendingFileRenameOperations
 
                 }


### PR DESCRIPTION
When using your improved version of the PendingReboot script with the CIM-methods I realised that the PendingFileRenameOperations is only returning correct values if the reg key is of type 'REG_SZ'. But if there is more than one rename operation pending this reg key is of type 'REG_MULTI_SZ' and the detection fails.

- added an if statement to query the reg key with CIM Method 'GetMultiStringValue' when 'GetStringValue' returns nothing.
- added code to improve the PendingFileRenameOperations list by removing empty lines from the list and removing leading characters from the path strings
- added / updated the comments to reflect that change
- changed parameter 'Name' to 'MethodName'
- fixed minor code formatting issues
